### PR TITLE
Add *.bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.btr
 *.rly
+*.bin


### PR DESCRIPTION
To ignore `relly.bin` after `make`.