### PR TITLE
Remove redundant page table deletion

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -156,7 +156,6 @@ impl BufferPoolManager {
                 self.disk
                     .write_page_data(evict_page_id, buffer.page.get_mut())?;
             }
-            self.page_table.remove(&evict_page_id);
             let page_id = self.disk.allocate_page();
             *buffer = Buffer::default();
             buffer.page_id = page_id;


### PR DESCRIPTION
The entry of the page table with key "$evict_page_id" 
will be also deleted at L168 right before inserting a new entry.

https://github.com/KOBA789/relly/blob/wdb/src/buffer.rs#L168

With this in mind, deleting the entry here looks redundant to me.

---

@KOBA789 :wave: What do you think? Many thanks